### PR TITLE
AB#208

### DIFF
--- a/views/publicusersearch/searchresultsmeasuredetail.ejs
+++ b/views/publicusersearch/searchresultsmeasuredetail.ejs
@@ -121,8 +121,7 @@
             <dt class="govuk-summary-list__key">
               Subsidy scheme description
             </dt>
-            <dd class="govuk-summary-list__value">
-              <%= searchmeasuredetails.subsidyMeasure.subsidySchemeDescription %>
+            <dd class="govuk-summary-list__value render-newlines"><%= searchmeasuredetails.subsidyMeasure.subsidySchemeDescription %>
             </dd>
           </div>
 


### PR DESCRIPTION
fix(searchresultsmeasuredetail.ejs): added the missing class attribute to render the description on a new line

