### PR TITLE
Ab#470 award details back button error

### DIFF
--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -27,11 +27,38 @@ router.get("/", async (req, res) => {
     console.log(`Status: ${awardapidata.status}`);
     console.log("Body: ", awardapidata.data);
     searchawarddetails = awardapidata.data;
+    const Referrer = Object.freeze({
+      searchresults:   "/searchresults",
+      schemedetailsroute:  "/scheme",
+      standaloneawards: "/standaloneawards"
+  });
+
+    var referrer;
+    if(searchawarddetails.standaloneAward == "Yes" && req.headers.referer.includes("/standaloneawards"))
+    {      
+      backButton_href = "/standaloneawards";
+      backButton_text = "Back to standalone awards";
+    }
+    else if(req.headers.referer.includes("/searchresults"))
+    {
+      backButton_href = "/searchresults";
+      backButton_text = "Back to search results";
+    }  
+    else if(req.headers.referer.includes("/scheme"))
+    {      
+      backButton_href = "/scheme/?scheme=" + searchmeasuredetails.scNumber;
+      backButton_text = "Back to scheme details";
+    }
+    else
+      throw new Error("Referrer not recognised")
 
     if (searchawarddetails.subsidyMeasure.status == "Deleted") {
       res.render("publicusersearch/noresults");
     } else {
-      res.render("publicusersearch/searchresultsawarddetail");
+      res.render("publicusersearch/searchresultsawarddetail", {
+        backButton_href,
+        backButton_text
+      });
     }
   } catch (err) {
 

--- a/views/publicusersearch/searchresults.ejs
+++ b/views/publicusersearch/searchresults.ejs
@@ -58,6 +58,8 @@
               "Standalone award": parsedResponse.awards[i].standaloneAward,
               "Subsidy control number": parsedResponse.awards[i].subsidyMeasure.scNumber,
               "Subsidy award description": parsedResponse.awards[i].subsidyAwardDescription ? parsedResponse.awards[i].subsidyAwardDescription : "",
+              "Public authority URL": (parsedResponse.awards[i].standaloneAward === "Yes") ? parsedResponse.awards[i].authorityURL : 'NA',
+              "Public authority URL Description": (parsedResponse.awards[i].standaloneAward === "Yes") ? parsedResponse.awards[i].authorityURLDescription : 'NA',
               "Subsidy award number": parsedResponse.awards[i].awardNumber,
               "Subsidy award status": parsedResponse.awards[i].status,
               "Subsidy scheme name": parsedResponse.awards[i].subsidyMeasure.subsidyMeasureTitle,

--- a/views/publicusersearch/searchresultsawarddetail.ejs
+++ b/views/publicusersearch/searchresultsawarddetail.ejs
@@ -7,15 +7,6 @@
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-145652997-21"></script>
-  <script>
-    // window.dataLayer = window.dataLayer || [];
-
-    // function gtag() {
-    //   dataLayer.push(arguments);
-    // }
-    // gtag('js', new Date());
-    // gtag('config', 'UA-145652997-21');
-  </script>
 </head>
 
 <body class="govuk-template__body app-example-page">
@@ -25,11 +16,9 @@
   <div class="govuk-width-container ">
     <%- include('../partials/banner.ejs') %>
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      <a <% if(searchawarddetails.standaloneAward.toLowerCase() == "yes"){ %>
-        href="/standaloneawards"
-      <% }else{ %>
-        href="/searchresults"
-      <% } %> class="govuk-back-link" aria-label="back to search results page">Back</a>
+      <a href=<%=backButton_href%> class="govuk-back-link" id="back-button-link">
+        Back
+      </a>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -40,10 +29,8 @@
         </div>
 
         <div class="govuk-grid-column-one-quarter">
-          <!-- <form action="/homepage" method="POST" >         -->
           <button class="govuk-button_cancel_last_xl" data-module="govuk-button" onclick="window.print()">
             Print page </button>
-          <!-- </form>   -->
         </div>
       </div>
 
@@ -314,8 +301,8 @@
 
 
         <div>
-          <button class="govuk-button" onClick="history.back()" data-module="govuk-button">
-            Back to search results </button>
+          <button class="govuk-button" id="back-button-large"onClick="window.location.href='<%=backButton_href%>'" data-module="govuk-button">
+            <%=backButton_text%> </button>
         </div>
     </main>
   </div>

--- a/views/publicusersearch/standaloneawards.ejs
+++ b/views/publicusersearch/standaloneawards.ejs
@@ -57,6 +57,8 @@
               "Standalone award": parsedResponse.awards[i].standaloneAward,
               "Subsidy control number": parsedResponse.awards[i].subsidyMeasure.scNumber,
               "Subsidy award description": parsedResponse.awards[i].subsidyAwardDescription ? parsedResponse.awards[i].subsidyAwardDescription : "",
+              "Public authority URL": parsedResponse.awards[i].authorityURL,
+              "Public authority URL Description": parsedResponse.awards[i].authorityURLDescription,
               "Subsidy award number": parsedResponse.awards[i].awardNumber,
               "Subsidy award status": parsedResponse.awards[i].status,
               "Subsidy scheme name": parsedResponse.awards[i].subsidyMeasure.subsidyMeasureTitle,


### PR DESCRIPTION
Fixed an issue where the back button href was incorrect causing an ejs error when attempting to load the "searchresults" page without some compulsory session variables