### PR TITLE
AB#754 web 2 http security headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,7 +140,19 @@ app.locals.awardnumber;
 app.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
   res.set("Cross-Origin-Resource-Policy", "same-origin");

--- a/app.js
+++ b/app.js
@@ -142,6 +142,7 @@ app.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
 
   res.render("publicusersearch/homepage");

--- a/app.js
+++ b/app.js
@@ -141,7 +141,7 @@ app.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
 
   res.render("publicusersearch/homepage");

--- a/app.js
+++ b/app.js
@@ -143,6 +143,9 @@ app.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
 
   res.render("publicusersearch/homepage");

--- a/app.js
+++ b/app.js
@@ -143,7 +143,7 @@ app.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);

--- a/app.js
+++ b/app.js
@@ -141,6 +141,7 @@ app.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
 
   res.render("publicusersearch/homepage");

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -7,6 +7,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("partials/accessibilityStatement");
 });

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -8,7 +8,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -4,7 +4,19 @@ const router = express.Router();
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -8,6 +8,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("partials/accessibilityStatement");
 });

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -6,7 +6,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("partials/accessibilityStatement");
 });

--- a/routes/accessibilityStatement.js
+++ b/routes/accessibilityStatement.js
@@ -1,29 +1,9 @@
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("partials/accessibilityStatement");
 });
 

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -5,6 +5,7 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 // ********************************************************
 // Read environment property file and set the API URL end points
@@ -47,27 +48,7 @@ if (Environment_variable == "env=local") {
 }
 
 router.post("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   var { homepage_button } = req.body;
 
@@ -82,28 +63,7 @@ router.post("/", async (req, res) => {
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/beneficiaryname");
 });
 

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -53,6 +53,9 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   var { homepage_button } = req.body;
 
@@ -73,6 +76,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/beneficiaryname");
 });

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -52,6 +52,7 @@ router.post("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   var { homepage_button } = req.body;
 
@@ -71,6 +72,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/beneficiaryname");
 });

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -51,7 +51,7 @@ router.post("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   var { homepage_button } = req.body;
 
@@ -70,7 +70,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/beneficiaryname");
 });

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -49,7 +49,19 @@ if (Environment_variable == "env=local") {
 router.post("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -72,7 +84,19 @@ router.post("/", async (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/beneficiaryname.js
+++ b/routes/beneficiaryname.js
@@ -53,7 +53,7 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -76,7 +76,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -9,6 +9,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/cookies-help");
 });

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -8,7 +8,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/cookies-help");
 });

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -1,31 +1,11 @@
 const express = require("express");
 var session = require("express-session");
 const router = express.Router();
+const utils = require("../utils");
 
 router.get("/", (req, res) => {
   ssn = req.session;
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/cookies-help");
 });
 

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -10,6 +10,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/cookies-help");
 });

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -6,7 +6,19 @@ router.get("/", (req, res) => {
   ssn = req.session;
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/cookies-help.js
+++ b/routes/cookies-help.js
@@ -10,7 +10,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -1,29 +1,9 @@
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/feedbackform");
 });
 

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -8,7 +8,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -4,7 +4,19 @@ const router = express.Router();
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -7,6 +7,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/feedbackform");
 });

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -8,6 +8,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/feedbackform");
 });

--- a/routes/feedbackform.js
+++ b/routes/feedbackform.js
@@ -6,7 +6,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/feedbackform");
 });

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -4,59 +4,19 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
   var { showfiter } = req.body;
   console.log("showfiter" + showfiter);
 
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   res.render("publicusersearch/filtersearch", { current_page_active });
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   console.log("current page from filtersearch :" + current_page_active);
   res.render("publicusersearch/filtersearch", { current_page_active });
 });

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -15,7 +15,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -29,7 +29,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -13,7 +13,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/filtersearch", { current_page_active });
 });
@@ -23,7 +23,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("current page from filtersearch :" + current_page_active);
   res.render("publicusersearch/filtersearch", { current_page_active });

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -14,6 +14,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/filtersearch", { current_page_active });
 });
@@ -24,6 +25,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("current page from filtersearch :" + current_page_active);
   res.render("publicusersearch/filtersearch", { current_page_active });

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -11,7 +11,19 @@ router.post("/", (req, res) => {
 
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -25,7 +37,19 @@ router.post("/", (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/filtersearch.js
+++ b/routes/filtersearch.js
@@ -15,6 +15,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/filtersearch", { current_page_active });
 });
@@ -26,6 +29,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("current page from filtersearch :" + current_page_active);
   res.render("publicusersearch/filtersearch", { current_page_active });

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -13,7 +13,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   //  routing_pagenumber =   req.query.page;
   routing_pagenumber = current_page_active;
@@ -111,7 +111,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -6,30 +6,11 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
   console.log("req.query.page: " + req.query.page);
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   //  routing_pagenumber =   req.query.page;
   routing_pagenumber = current_page_active;
@@ -123,28 +104,7 @@ router.get("/", async (req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/searchresults");
 });
 

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -11,7 +11,19 @@ router.get("/", async (req, res) => {
   console.log("req.query.page: " + req.query.page);
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -113,7 +125,19 @@ router.get("/", async (req, res) => {
 router.post("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -15,6 +15,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   //  routing_pagenumber =   req.query.page;
   routing_pagenumber = current_page_active;
@@ -114,6 +117,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -14,6 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   //  routing_pagenumber =   req.query.page;
   routing_pagenumber = current_page_active;
@@ -112,6 +113,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/hidefilter.js
+++ b/routes/hidefilter.js
@@ -15,7 +15,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -117,7 +117,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -12,7 +12,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   radio_beneficiaryname = "";
   text_beneficiaryname = "";
@@ -87,7 +87,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/homepage");
 });

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -14,6 +14,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   radio_beneficiaryname = "";
   text_beneficiaryname = "";
@@ -90,6 +93,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/homepage");
 });

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -14,7 +14,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -93,7 +93,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -4,31 +4,12 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
   // All declarations goes here
 
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   radio_beneficiaryname = "";
   text_beneficiaryname = "";
@@ -99,28 +80,7 @@ router.post("/", (req, res) => {
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/homepage");
 });
 

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -10,7 +10,19 @@ router.post("/", (req, res) => {
 
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -89,7 +101,19 @@ router.post("/", (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/homepage.js
+++ b/routes/homepage.js
@@ -13,6 +13,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   radio_beneficiaryname = "";
   text_beneficiaryname = "";
@@ -88,6 +89,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/homepage");
 });

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -209,7 +209,19 @@ router.post("/", (req, res) => {
 
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -223,7 +235,19 @@ router.post("/", (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -211,7 +211,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/legalgrantingdate");
 });
@@ -221,7 +221,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/legalgrantingdate");
 });

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -4,8 +4,11 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+  
   var { subsidyinstrument0 } = req.body;
   var { subsidyinstrument1 } = req.body;
   var { subsidyinstrument2 } = req.body;
@@ -207,54 +210,11 @@ router.post("/", (req, res) => {
   date_legal_granting_date_month1 = "";
   date_legal_granting_date_year1 = "";
 
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
   res.render("publicusersearch/legalgrantingdate");
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/legalgrantingdate");
 });
 

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -213,6 +213,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/legalgrantingdate");
 });
@@ -224,6 +227,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/legalgrantingdate");
 });

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -213,7 +213,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -227,7 +227,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/legalgrantingdate.js
+++ b/routes/legalgrantingdate.js
@@ -212,6 +212,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/legalgrantingdate");
 });
@@ -222,6 +223,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/legalgrantingdate");
 });

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -10,7 +10,19 @@ var request = require("request");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -6,29 +6,10 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   mfaAwardNumber = req.query.id;
   var endpoint =

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   mfaAwardNumber = req.query.id;
   var endpoint =

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -13,6 +13,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   mfaAwardNumber = req.query.id;
   var endpoint =

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -14,6 +14,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   mfaAwardNumber = req.query.id;
   var endpoint =

--- a/routes/mfaawarddetails.js
+++ b/routes/mfaawarddetails.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -8,29 +8,10 @@ const axios = require("axios");
 var request = require("request");
 const { debug } = require("request");
 const render = "publicusersearch/mfaawards";
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -16,6 +16,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -15,6 +15,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -16,7 +16,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/mfaawards.js
+++ b/routes/mfaawards.js
@@ -12,7 +12,19 @@ const render = "publicusersearch/mfaawards";
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -11,6 +11,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/noresults");
 });
@@ -21,6 +22,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/noresults");
 });

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -10,7 +10,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/noresults");
 });
@@ -20,7 +20,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/noresults");
 });

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -8,7 +8,19 @@ const router = express.Router();
 router.post("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -22,7 +34,19 @@ router.post("/", (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -12,7 +12,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -26,7 +26,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -12,6 +12,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/noresults");
 });
@@ -23,6 +26,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/noresults");
 });

--- a/routes/noresults.js
+++ b/routes/noresults.js
@@ -4,56 +4,15 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/noresults");
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/noresults");
 });
 

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -122,6 +122,7 @@ router.get("/", async (req, res) => {
     res.set("Content-Security-Policy", 'frame-ancestors "self"');
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+    res.set("Referrer-Policy", "origin");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -145,6 +146,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -121,7 +121,7 @@ router.get("/", async (req, res) => {
     res.set("X-Content-Type-Options", "nosniff");
     res.set("Content-Security-Policy", 'frame-ancestors "self"');
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -144,7 +144,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -119,7 +119,19 @@ router.get("/", async (req, res) => {
     console.log("page count: " + pageCount);
     res.set("X-Frame-Options", "DENY");
     res.set("X-Content-Type-Options", "nosniff");
-    res.set("Content-Security-Policy", 'frame-ancestors "self"');
+    res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
@@ -146,7 +158,19 @@ router.get("/", async (req, res) => {
 router.post("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -6,8 +6,11 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+
   console.log("req.query.page: " + req.query.sort);
   routing_pagenumber = req.query.sort;
   console.log("Records per page :" + routing_pagenumber) ;
@@ -117,27 +120,6 @@ router.get("/", async (req, res) => {
     console.log("Start Page :" + start_page);
     console.log("end page :" + end_page);
     console.log("page count: " + pageCount);
-    res.set("X-Frame-Options", "DENY");
-    res.set("X-Content-Type-Options", "nosniff");
-    res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-    res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-    res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -156,28 +138,7 @@ router.get("/", async (req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/searchresults");
 });
 

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -123,6 +123,9 @@ router.get("/", async (req, res) => {
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -147,6 +150,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/searchresults");
 });

--- a/routes/pageperroute.js
+++ b/routes/pageperroute.js
@@ -123,7 +123,7 @@ router.get("/", async (req, res) => {
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -150,7 +150,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -206,6 +206,9 @@ router.get("/", async (req, res) => {
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -228,6 +231,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   legalgrantingdate_arrow = "downacending";
   res.render("publicusersearch/searchresults");

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -202,7 +202,19 @@ router.get("/", async (req, res) => {
 
     res.set("X-Frame-Options", "DENY");
     res.set("X-Content-Type-Options", "nosniff");
-    res.set("Content-Security-Policy", 'frame-ancestors "self"');
+    res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
@@ -227,7 +239,19 @@ router.get("/", async (req, res) => {
 router.post("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -205,6 +205,7 @@ router.get("/", async (req, res) => {
     res.set("Content-Security-Policy", 'frame-ancestors "self"');
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+    res.set("Referrer-Policy", "origin");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -226,6 +227,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   legalgrantingdate_arrow = "downacending";
   res.render("publicusersearch/searchresults");

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -206,7 +206,7 @@ router.get("/", async (req, res) => {
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
     res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -231,7 +231,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -6,8 +6,11 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+
   console.log("req.query.page: " + req.query.page);
   console.log("beneficiary_sorting_order :" + beneficiary_sorting_order);
 
@@ -200,28 +203,6 @@ router.get("/", async (req, res) => {
     console.log("end page :" + end_page);
     console.log("page count: " + pageCount);
 
-    res.set("X-Frame-Options", "DENY");
-    res.set("X-Content-Type-Options", "nosniff");
-    res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-    res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-    res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
     res.render("publicusersearch/searchresults", {
       pageCount,
       previous_page,
@@ -237,28 +218,7 @@ router.get("/", async (req, res) => {
 });
 
 router.post("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   legalgrantingdate_arrow = "downacending";
   res.render("publicusersearch/searchresults");
 });

--- a/routes/pageroute.js
+++ b/routes/pageroute.js
@@ -204,7 +204,7 @@ router.get("/", async (req, res) => {
     res.set("X-Content-Type-Options", "nosniff");
     res.set("Content-Security-Policy", 'frame-ancestors "self"');
     res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
     res.render("publicusersearch/searchresults", {
       pageCount,
@@ -225,7 +225,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   legalgrantingdate_arrow = "downacending";
   res.render("publicusersearch/searchresults");

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -8,7 +8,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/privacy-notice");
 });

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -1,31 +1,11 @@
 const express = require("express");
 var session = require("express-session");
 const router = express.Router();
+const utils = require("../utils");
 
 router.get("/", (req, res) => {
   ssn = req.session;
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/privacy-notice");
 });
 

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -10,6 +10,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/privacy-notice");
 });

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -6,7 +6,19 @@ router.get("/", (req, res) => {
   ssn = req.session;
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -9,6 +9,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/privacy-notice");
 });

--- a/routes/privacy-notice.js
+++ b/routes/privacy-notice.js
@@ -10,7 +10,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -11,7 +11,19 @@ var utils = require("../utils");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -13,7 +13,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.query.scnumber: " + req.query.scheme);
   scheme = req.query.scheme;

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -14,6 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.query.scnumber: " + req.query.scheme);
   scheme = req.query.scheme;

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -15,7 +15,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -6,30 +6,10 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
-var utils = require("../utils");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("req.query.scnumber: " + req.query.scheme);
   scheme = req.query.scheme;

--- a/routes/schemedetailsroute.js
+++ b/routes/schemedetailsroute.js
@@ -15,6 +15,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.query.scnumber: " + req.query.scheme);
   scheme = req.query.scheme;

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -16,6 +16,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -9,29 +9,10 @@ var request = require("request");
 const { debug } = require("request");
 const render = "publicusersearch/schemes";
 const validateDate = require("validate-date");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -13,7 +13,19 @@ const validateDate = require("validate-date");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -17,6 +17,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -15,7 +15,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   try{
     const gaListRequest = await axios.get(

--- a/routes/schemes.js
+++ b/routes/schemes.js
@@ -17,7 +17,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -8,30 +8,10 @@ const router = express.Router();
 
 const axios = require("axios");
 var request = require("request");
-var utils = require("../utils");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("scNumber: " + req.query.scNumber);
   console.log("version: " + req.query.version);

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -13,7 +13,19 @@ var utils = require("../utils");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -17,6 +17,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("scNumber: " + req.query.scNumber);
   console.log("version: " + req.query.version);

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -15,7 +15,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("scNumber: " + req.query.scNumber);
   console.log("version: " + req.query.version);

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -16,6 +16,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("scNumber: " + req.query.scNumber);
   console.log("version: " + req.query.version);

--- a/routes/schemeversionroute.js
+++ b/routes/schemeversionroute.js
@@ -17,7 +17,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -15,6 +15,9 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("HOMEPAGE button", req.body.homepage_button);
   if (req.body.homepage_button == "show_results") {
@@ -808,6 +811,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/searchresults", {
     date_legal_granting_date_day,

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -15,7 +15,7 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -811,7 +811,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -13,7 +13,7 @@ router.post("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("HOMEPAGE button", req.body.homepage_button);
   if (req.body.homepage_button == "show_results") {
@@ -805,7 +805,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/searchresults", {
     date_legal_granting_date_day,

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -7,29 +7,10 @@ const router = express.Router();
 const axios = require("axios");
 var request = require("request");
 const { debug } = require("request");
+const utils = require("../utils");
 
 router.post("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("HOMEPAGE button", req.body.homepage_button);
   if (req.body.homepage_button == "show_results") {
@@ -744,9 +725,26 @@ router.post("/", async (req, res) => {
           data,
           {
             headers: {
-              "X-Content-Type-Options": "nosniff",
               "X-Frame-Options": "DENY",
-              "Content-Security-Policy": "frame-ancestors 'self'",
+              "X-Content-Type-Options": "nosniff",
+              "Access-Control-Allow-Origin": beis_url_publicsearch,
+              "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+              "Content-Security-Policy": [
+                "default-src 'self'",
+                "script-src 'self' 'unsafe-inline'",
+                "style-src 'self' 'unsafe-inline'",
+                "img-src 'self' data:",
+                "font-src 'self' data:",
+                "connect-src 'self'",
+                "object-src 'none'",
+                "base-uri 'self'",
+                "form-action 'self'",
+                "frame-ancestors 'none'"
+              ].join("; "),
+              "Referrer-Policy": "origin",
+              "Cross-Origin-Resource-Policy": "same-origin",
+              "Cross-Origin-Opener-Policy": "same-origin",
+              "Cross-Origin-Embedder-Policy": "require-corp",
             },
           }
         );
@@ -817,27 +815,7 @@ router.post("/", async (req, res) => {
 });
 
 router.get("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   res.render("publicusersearch/searchresults", {
     date_legal_granting_date_day,

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -11,7 +11,19 @@ const { debug } = require("request");
 router.post("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -807,7 +819,19 @@ router.post("/", async (req, res) => {
 router.get("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/searchresults.js
+++ b/routes/searchresults.js
@@ -14,6 +14,7 @@ router.post("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("HOMEPAGE button", req.body.homepage_button);
   if (req.body.homepage_button == "show_results") {
@@ -806,6 +807,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/searchresults", {
     date_legal_granting_date_day,

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -10,7 +10,19 @@ var request = require("request");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -13,6 +13,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.query.page: " + req.query.page);
   awardnumber = req.query.page;

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -14,6 +14,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.query.page: " + req.query.page);
   awardnumber = req.query.page;

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.query.page: " + req.query.page);
   awardnumber = req.query.page;

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/searchresultsawardroute.js
+++ b/routes/searchresultsawardroute.js
@@ -6,29 +6,10 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("req.query.page: " + req.query.page);
   awardnumber = req.query.page;

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -10,7 +10,19 @@ var request = require("request");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -6,29 +6,10 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("req.query.page: " + req.query.page);
   scnumber = req.query.page;

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.query.page: " + req.query.page);
   scnumber = req.query.page;

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -13,6 +13,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.query.page: " + req.query.page);
   scnumber = req.query.page;

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -14,6 +14,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.query.page: " + req.query.page);
   scnumber = req.query.page;

--- a/routes/searchresultsmeasureroute.js
+++ b/routes/searchresultsmeasureroute.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -11,6 +11,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;
@@ -300,6 +301,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/spendingsector");
 });

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -8,7 +8,19 @@ const router = express.Router();
 router.post("/", (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -301,7 +313,19 @@ router.get("/", (req, res) => {
   spending_sector_isfirst = "No";
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -4,29 +4,10 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;
@@ -311,28 +292,7 @@ router.post("/", (req, res) => {
 
 router.get("/", (req, res) => {
   spending_sector_isfirst = "No";
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/spendingsector");
 });
 

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -12,6 +12,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;
@@ -302,6 +305,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/spendingsector");
 });

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -10,7 +10,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;
@@ -299,7 +299,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/spendingsector");
 });

--- a/routes/spendingsector.js
+++ b/routes/spendingsector.js
@@ -12,7 +12,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -305,7 +305,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -16,7 +16,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   frontend_totalRecordsPerPage = 10;
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -10,29 +10,10 @@ const { debug } = require("request");
 const { json } = require("express");
 const { data } = require("jquery");
 const render = "publicusersearch/standaloneawards";
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   frontend_totalRecordsPerPage = 10;
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -18,7 +18,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -18,6 +18,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   frontend_totalRecordsPerPage = 10;
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -17,6 +17,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   frontend_totalRecordsPerPage = 10;
 

--- a/routes/standaloneawards.js
+++ b/routes/standaloneawards.js
@@ -14,7 +14,19 @@ const render = "publicusersearch/standaloneawards";
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -9,7 +9,7 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -9,6 +9,9 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.body.feedback", req.body.feedback);
   console.log("req.body.comment", req.body.comment);

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -8,6 +8,7 @@ router.post("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.body.feedback", req.body.feedback);
   console.log("req.body.comment", req.body.comment);

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -1,29 +1,10 @@
 const express = require("express");
 const axios = require("axios");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("req.body.feedback", req.body.feedback);
   console.log("req.body.comment", req.body.comment);

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -7,7 +7,7 @@ router.post("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.body.feedback", req.body.feedback);
   console.log("req.body.comment", req.body.comment);

--- a/routes/submitfeedback.js
+++ b/routes/submitfeedback.js
@@ -5,7 +5,19 @@ const router = express.Router();
 router.post("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -4,8 +4,11 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+
   const { spendingsector0 } = req.body;
   const { spendingsector1 } = req.body;
   const { spendingsector2 } = req.body;
@@ -358,55 +361,12 @@ router.post("/", (req, res) => {
 
   console.log(" actual_spending_sector:" + actual_spending_sector);
 
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
   res.render("publicusersearch/subsidyinstrument");
 });
 
 router.get("/", (req, res) => {
   subsidy_instrument_isfirst = "No";
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/subsidyinstrument");
 });
 

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -362,7 +362,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/subsidyinstrument");
 });
@@ -373,7 +373,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/subsidyinstrument");
 });

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -364,6 +364,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/subsidyinstrument");
 });
@@ -376,6 +379,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/subsidyinstrument");
 });

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -363,6 +363,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/subsidyinstrument");
 });
@@ -374,6 +375,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/subsidyinstrument");
 });

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -364,7 +364,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -379,7 +379,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/subsidyinstrument.js
+++ b/routes/subsidyinstrument.js
@@ -360,7 +360,19 @@ router.post("/", (req, res) => {
 
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -375,7 +387,19 @@ router.get("/", (req, res) => {
   subsidy_instrument_isfirst = "No";
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -40,7 +40,19 @@ router.post("/", (req, res) => {
   }
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
@@ -55,7 +67,19 @@ router.get("/", (req, res) => {
   subsidy_objective_isfirst = "No";
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -4,8 +4,11 @@
 
 const express = require("express");
 const router = express.Router();
+const utils = require("../utils");
 
 router.post("/", (req, res) => {
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+
   const { Beneficiary_name, beneficiaryname } = req.body;
   text_beneficiaryname = Beneficiary_name;
   radio_beneficiaryname = beneficiaryname;
@@ -38,55 +41,13 @@ router.post("/", (req, res) => {
     check_subsidyobjective12 = "";
     check_subsidyobjective12_pass = "";
   }
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/subsidyobjective");
 });
 
 router.get("/", (req, res) => {
   subsidy_objective_isfirst = "No";
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
   res.render("publicusersearch/subsidyobjective");
 });
 

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -43,6 +43,7 @@ router.post("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/subsidyobjective");
 });
@@ -54,6 +55,7 @@ router.get("/", (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   res.render("publicusersearch/subsidyobjective");
 });

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -42,7 +42,7 @@ router.post("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/subsidyobjective");
 });
@@ -53,7 +53,7 @@ router.get("/", (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   res.render("publicusersearch/subsidyobjective");
 });

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -44,6 +44,9 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/subsidyobjective");
 });
@@ -56,6 +59,9 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   res.render("publicusersearch/subsidyobjective");
 });

--- a/routes/subsidyobjective.js
+++ b/routes/subsidyobjective.js
@@ -44,7 +44,7 @@ router.post("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
@@ -59,7 +59,7 @@ router.get("/", (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -17,6 +17,9 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -17,7 +17,7 @@ router.post("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -13,7 +13,19 @@ router.post("/", async (req, res) => {
   // ***************************************************************
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -15,7 +15,7 @@ router.post("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -6,33 +6,14 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.post("/", async (req, res) => {
   // ***************************************************************
   // Subsidy objective read section from filter display results call
   // ***************************************************************
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+  
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;
   var { subsidyobjective2 } = req.body;

--- a/routes/updateresults.js
+++ b/routes/updateresults.js
@@ -16,6 +16,7 @@ router.post("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   var { subsidyobjective0 } = req.body;
   var { subsidyobjective1 } = req.body;

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -10,7 +10,19 @@ var request = require("request");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -14,6 +14,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -13,6 +13,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -6,30 +6,11 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
-
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
+  
   console.log("req.query.page: " + req.query.page);
 
   console.log("req.query.page: " + req.query.sort);

--- a/routes/updateresultspageperroute.js
+++ b/routes/updateresultspageperroute.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -10,7 +10,19 @@ var request = require("request");
 router.get("/", async (req, res) => {
   res.set("X-Frame-Options", "DENY");
   res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", 'frame-ancestors "self"');
+  res.set("Content-Security-Policy", [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'"
+  ].join(";"));
+
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -14,6 +14,9 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
+  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.set("Cross-Origin-Embedder-Policy", "require-corp");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
   res.set("X-Content-Type-Options", "nosniff");
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -13,6 +13,7 @@ router.get("/", async (req, res) => {
   res.set("Content-Security-Policy", 'frame-ancestors "self"');
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  res.set("Referrer-Policy", "origin");
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -6,29 +6,10 @@ const express = require("express");
 const router = express.Router();
 const axios = require("axios");
 var request = require("request");
+const utils = require("../utils");
 
 router.get("/", async (req, res) => {
-  res.set("X-Frame-Options", "DENY");
-  res.set("X-Content-Type-Options", "nosniff");
-  res.set("Content-Security-Policy", [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
-    "font-src 'self' data:",
-    "connect-src 'self'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'self'"
-  ].join(";"));
-
-  res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
-  res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
-  res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "same-origin");
-  res.set("Cross-Origin-Opener-Policy", "same-origin");
-  res.set("Cross-Origin-Embedder-Policy", "require-corp");
+  utils.setSecurityHeaders(res, beis_url_publicsearch);
 
   console.log("req.query.page: " + req.query.page);
 

--- a/routes/updateresultsroute.js
+++ b/routes/updateresultsroute.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
   res.set("Access-Control-Allow-Origin", beis_url_publicsearch);
   res.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   res.set("Referrer-Policy", "origin");
-  res.set("Cross-Origin-Resource-Policy", "cross-origin");
+  res.set("Cross-Origin-Resource-Policy", "same-origin");
   res.set("Cross-Origin-Opener-Policy", "same-origin");
   res.set("Cross-Origin-Embedder-Policy", "require-corp");
 

--- a/utils.js
+++ b/utils.js
@@ -18,3 +18,28 @@ setURIParameters = function (uri, paramValues) {
   const returnUrl = new URL(uri);
   return returnUrl.pathname + returnUrl.search + returnUrl.hash;
 }
+
+exports.setSecurityHeaders = function (res, url) {
+  res.set({
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Access-Control-Allow-Origin": url,
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+    "Content-Security-Policy": [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "font-src 'self' data:",
+      "connect-src 'self'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'"
+    ].join("; "),
+    "Referrer-Policy": "origin",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Embedder-Policy": "require-corp",
+  });
+}


### PR DESCRIPTION
across all accessible routes:
1. hsts header added where missing, and updated to match suggested configuration
2. csp added with as strict a policy as could be included without breaking functionality
3. corp, coep, coop headers added as suggested
4. referrer policy added